### PR TITLE
BME-222 Potential fix for NPE triggered by Mekanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 apply plugin: 'org.spongepowered.mixin'
 
-version = '0.4.4-beta'
+version = '0.4.5-dev.0'
 group = 'lordfokas.cartography' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Cartography-${minecraft_version}"
 

--- a/src/main/java/lordfokas/cartography/feature/discovery/DiscoveryHandler.java
+++ b/src/main/java/lordfokas/cartography/feature/discovery/DiscoveryHandler.java
@@ -41,7 +41,7 @@ public class DiscoveryHandler {
         // This will not work on the dedicated server
         if (FMLEnvironment.dist == Dist.CLIENT) {
             Minecraft mc = Minecraft.getInstance();
-            if(player.getUUID() != mc.player.getUUID()) return;
+            if(mc.player == null || player.getUUID() != mc.player.getUUID()) return;
         }
 
         Level level = player.getLevel();


### PR DESCRIPTION
A `NullPointerException` was unveiled by somebody trying to use Carto with Mekanism. Just updating the check to make sure vaariable not `null` before querying it. 

Haven't replicated the original bug to validate this fixes it, since I don't know enough about the setup that triggered it. But based on the logs provided, this should in theory fix the issue. A dev copy of this build has been uploaded in the testers channels to be passed along to the original reporter to validate the fix works.

Once the fix has been validated, will create a paired PR for 1.20.1.